### PR TITLE
Created TextPickerCell and added to the SettingsViewPage

### DIFF
--- a/Sample/Sample.Droid/Sample.Droid.csproj
+++ b/Sample/Sample.Droid/Sample.Droid.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Sample.Droid</RootNamespace>
     <AssemblyName>Sample.Droid</AssemblyName>
-    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
@@ -59,9 +59,6 @@
     </Reference>
     <Reference Include="Prism.Unity.Forms">
       <HintPath>..\packages\Prism.Unity.Forms.6.3.0\lib\MonoAndroid1.0\Prism.Unity.Forms.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\packages\System.Reactive.Interfaces.3.0.0\lib\netstandard1.0\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\System.Reactive.Core.3.0.0\lib\netstandard1.3\System.Reactive.Core.dll</HintPath>
@@ -155,26 +152,27 @@
     <Reference Include="Xamarin.Forms.Platform.Android">
       <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
       <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
-    <Reference Include="SettingsView">
-      <HintPath>..\packages\AiForms.SettingsView.0.2.0-pre3\lib\MonoAndroid\SettingsView.dll</HintPath>
-    </Reference>
-    <Reference Include="SettingsView.Droid">
-      <HintPath>..\packages\AiForms.SettingsView.0.2.0-pre3\lib\MonoAndroid\SettingsView.Droid.dll</HintPath>
-    </Reference>
     <Reference Include="AiForms.Layouts">
       <HintPath>..\packages\AiForms.Layouts.1.0.3\lib\netstandard1.1\AiForms.Layouts.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces">
+      <HintPath>..\packages\System.Reactive.Interfaces.3.0.0\lib\netstandard1.0\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sample\Sample.csproj">
       <Project>{2DB58246-77D5-4190-B0A0-F125B538309B}</Project>
       <Name>Sample</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\SettingsView.Droid\SettingsView.Droid.csproj">
+      <Project>{2CC418E1-CE33-48E2-8E89-A87669BD9E28}</Project>
+      <Name>SettingsView.Droid</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Sample/Sample.Droid/packages.config
+++ b/Sample/Sample.Droid/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="AiForms.Effects" version="1.1.0-pre1" targetFramework="monoandroid80" />
   <package id="AiForms.Layouts" version="1.0.3" targetFramework="monoandroid80" />
-  <package id="AiForms.SettingsView" version="0.2.0-pre3" targetFramework="monoandroid80" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="monoandroid71" />
   <package id="NGraphics" version="0.4.0" targetFramework="monoandroid71" />
   <package id="Prism.Core" version="6.3.0" targetFramework="monoandroid71" />

--- a/Sample/Sample.iOS/Sample.iOS.csproj
+++ b/Sample/Sample.iOS/Sample.iOS.csproj
@@ -83,9 +83,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Practices.Unity">
       <HintPath>..\packages\Unity.4.0.1\lib\portable-net45+wp80+win8+wpa81+MonoAndroid10+MonoTouch10\Microsoft.Practices.Unity.dll</HintPath>
     </Reference>
@@ -146,20 +143,21 @@
     <Reference Include="Xamarin.Forms.Xaml">
       <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
     </Reference>
-    <Reference Include="SettingsView">
-      <HintPath>..\packages\AiForms.SettingsView.0.2.0-pre3\lib\Xamarin.iOS10\SettingsView.dll</HintPath>
-    </Reference>
-    <Reference Include="SettingsView.iOS">
-      <HintPath>..\packages\AiForms.SettingsView.0.2.0-pre3\lib\Xamarin.iOS10\SettingsView.iOS.dll</HintPath>
-    </Reference>
     <Reference Include="AiForms.Layouts">
       <HintPath>..\packages\AiForms.Layouts.1.0.3\lib\netstandard1.1\AiForms.Layouts.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation">
+      <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Sample\Sample.csproj">
       <Project>{2DB58246-77D5-4190-B0A0-F125B538309B}</Project>
       <Name>Sample</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\SettingsView.iOS\SettingsView.iOS.csproj">
+      <Project>{4601EE49-52E1-448E-98A1-EFDCBA7A64AC}</Project>
+      <Name>SettingsView.iOS</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Sample/Sample.iOS/packages.config
+++ b/Sample/Sample.iOS/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="AiForms.Effects" version="1.1.0-pre1" targetFramework="xamarinios10" />
   <package id="AiForms.Layouts" version="1.0.3" targetFramework="xamarinios10" />
-  <package id="AiForms.SettingsView" version="0.2.0-pre3" targetFramework="xamarinios10" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="xamarinios10" />
   <package id="NGraphics" version="0.4.0" targetFramework="xamarinios10" />
   <package id="Prism.Core" version="6.3.0" targetFramework="xamarinios10" />

--- a/Sample/Sample/Sample.csproj
+++ b/Sample/Sample/Sample.csproj
@@ -260,6 +260,12 @@
   <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\SettingsView\SettingsView.csproj">
+      <Project>{8FFB1EF3-FAF3-478C-B9F1-4D02E599C3C6}</Project>
+      <Name>SettingsView</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- <Import Project="..\packages\Xamarin.Forms.2.5.0.121934\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.5.0.121934\build\portable-win+net45+wp80+win81+wpa81\Xamarin.Forms.targets')" /> -->
 </Project>

--- a/Sample/Sample/Sample.nuget.props
+++ b/Sample/Sample/Sample.nuget.props
@@ -3,9 +3,9 @@
   <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
     <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
     <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
-    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">/Users/kamu/Projects/AiForms.Renderers/Sample/Sample/project.lock.json</ProjectAssetsFile>
-    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">/Users/kamu/.nuget/packages/</NuGetPackageRoot>
-    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">/Users/kamu/.nuget/packages/</NuGetPackageFolders>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">/Users/jeff/Projects/AiForms.Renderers/Sample/Sample/project.lock.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">/Users/jeff/.nuget/packages/</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">/Users/jeff/.nuget/packages/</NuGetPackageFolders>
     <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">ProjectJson</NuGetProjectStyle>
     <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.3.1</NuGetToolVersion>
   </PropertyGroup>

--- a/Sample/Sample/Views/SettingsViewPage.xaml
+++ b/Sample/Sample/Views/SettingsViewPage.xaml
@@ -82,10 +82,17 @@
             SelectedItems="{Binding SelectedItems}" KeepSelectedUntilBack="true" PageTitle="select 3 items" />
         </sv:Section>
 
-        <sv:Section Title="Picker 3 Brothers">
+        <sv:Section Title="Picker 4 Brothers">
             <sv:NumberPickerCell Title="NumberPicker" Min="0" Max="99" Number="15" PickerTitle="Select number" />
             <sv:TimePickerCell Title="TimePicker" Format="HH:mm" Time="15:30" PickerTitle="Select time" />
             <sv:DatePickerCell Title="DatePicker" Format="yyyy/MM/dd (ddd)" Date="2017/11/11" MinimumDate="2015/1/1" MaximumDate="2018/12/15" TodayText="Today's date"/>
+            <sv:TextPickerCell Title="TextPicker" SelectedItem="Green">
+                <sv:TextPickerCell.Items>
+                    <x:String>Red</x:String>
+                    <x:String>Green</x:String>
+                    <x:String>Blue</x:String>
+                </sv:TextPickerCell.Items>                 
+            </sv:TextPickerCell>
         </sv:Section>    
 
         <sv:Section Title="Input" IsVisible="{Binding InputSectionVisible.Value}">

--- a/SettingsView.Droid/Cells/TextPickerCellRenderer.cs
+++ b/SettingsView.Droid/Cells/TextPickerCellRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Windows.Input;
 using AiForms.Renderers;
 using AiForms.Renderers.Droid;
@@ -9,22 +10,22 @@ using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using APicker = Android.Widget.NumberPicker;
 
-[assembly: ExportRenderer(typeof(NumberPickerCell), typeof(NumberPickerCellRenderer))]
+[assembly: ExportRenderer(typeof(TextPickerCell), typeof(TextPickerCellRenderer))]
 namespace AiForms.Renderers.Droid
 {
     /// <summary>
     /// Number picker cell renderer.
     /// </summary>
     [Android.Runtime.Preserve(AllMembers = true)]
-    public class NumberPickerCellRenderer : CellBaseRenderer<NumberPickerCellView> { }
+    public class TextPickerCellRenderer : CellBaseRenderer<TextPickerCellView> { }
 
     /// <summary>
     /// Number picker cell view.
     /// </summary>
     [Android.Runtime.Preserve(AllMembers = true)]
-    public class NumberPickerCellView : LabelCellView, IPickerCell
+    public class TextPickerCellView : LabelCellView, IPickerCell
     {
-        NumberPickerCell _NumberPikcerCell => Cell as NumberPickerCell;
+        TextPickerCell _TextPickerCell => Cell as TextPickerCell;
         APicker _picker;
         AlertDialog _dialog;
         Context _context;
@@ -32,13 +33,14 @@ namespace AiForms.Renderers.Droid
         ICommand _command;
         int _max;
         int _min;
+        string[] _displayValues;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:AiForms.Renderers.Droid.NumberPickerCellView"/> class.
+        /// Initializes a new instance of the <see cref="T:AiForms.Renderers.Droid.TextPickerCellView"/> class.
         /// </summary>
         /// <param name="context">Context.</param>
         /// <param name="cell">Cell.</param>
-        public NumberPickerCellView(Context context, Cell cell) : base(context, cell)
+        public TextPickerCellView(Context context, Cell cell) : base(context, cell)
         {
             _context = context;
         }
@@ -51,19 +53,13 @@ namespace AiForms.Renderers.Droid
         public override void CellPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             base.CellPropertyChanged(sender, e);
-            if (e.PropertyName == NumberPickerCell.MinProperty.PropertyName) {
-                UpdateMin();
+            if (e.PropertyName == TextPickerCell.SelectedItemProperty.PropertyName) {
+                UpdateSelectedItem();
             }
-            else if (e.PropertyName == NumberPickerCell.MaxProperty.PropertyName) {
-                UpdateMax();
-            }
-            else if (e.PropertyName == NumberPickerCell.NumberProperty.PropertyName) {
-                UpdateNumber();
-            }
-            else if (e.PropertyName == NumberPickerCell.PickerTitleProperty.PropertyName) {
+            else if (e.PropertyName == TextPickerCell.PickerTitleProperty.PropertyName) {
                 UpdatePickerTitle();
             }
-            else if (e.PropertyName == NumberPickerCell.SelectedCommandProperty.PropertyName) {
+            else if (e.PropertyName == TextPickerCell.SelectedCommandProperty.PropertyName) {
                 UpdateCommand();
             }
         }
@@ -74,10 +70,9 @@ namespace AiForms.Renderers.Droid
         public override void UpdateCell()
         {
             base.UpdateCell();
-            UpdateMin();
-            UpdateMax();
             UpdatePickerTitle();
-            UpdateNumber();
+            UpdatePickerItems();
+            UpdateSelectedItem();
             UpdateCommand();
         }
 
@@ -107,29 +102,26 @@ namespace AiForms.Renderers.Droid
             CreateDialog();
         }
 
-        void UpdateMin()
+        void UpdateSelectedItem()
         {
-            _min = _NumberPikcerCell.Min;
-        }
-
-        void UpdateMax()
-        {
-            _max = _NumberPikcerCell.Max;
-        }
-
-        void UpdateNumber()
-        {
-            vValueLabel.Text = _NumberPikcerCell.Number.ToString();
+            vValueLabel.Text = _TextPickerCell.SelectedItem.ToString();
         }
 
         void UpdatePickerTitle()
         {
-            _title = _NumberPikcerCell.PickerTitle;
+            _title = _TextPickerCell.PickerTitle;
+        }
+
+        void UpdatePickerItems()
+        {
+            _min = 0;
+            _max = _TextPickerCell.Items.Count() - 1;
+            _displayValues = _TextPickerCell.Items.ToArray();
         }
 
         void UpdateCommand()
         {
-            _command = _NumberPikcerCell.SelectedCommand;
+            _command = _TextPickerCell.SelectedCommand;
         }
 
         void CreateDialog()
@@ -137,7 +129,8 @@ namespace AiForms.Renderers.Droid
             _picker = new APicker(_context);
             _picker.MinValue = _min;
             _picker.MaxValue = _max;
-            _picker.Value = _NumberPikcerCell.Number;
+            _picker.SetDisplayedValues(_displayValues);
+            _picker.Value = _TextPickerCell.Items.IndexOf(_TextPickerCell.SelectedItem);
 
             if (_dialog == null) {
                 using (var builder = new AlertDialog.Builder(_context)) {
@@ -152,13 +145,11 @@ namespace AiForms.Renderers.Droid
                     builder.SetView(parent);
 
 
-                    builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) =>
-                    {
+                    builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) => {
                         ClearFocus();
                     });
-                    builder.SetPositiveButton(global::Android.Resource.String.Ok, (o, args) =>
-                    {
-                        _NumberPikcerCell.Number = _picker.Value;
+                    builder.SetPositiveButton(global::Android.Resource.String.Ok, (o, args) => {
+                        _TextPickerCell.SelectedItem = _displayValues[_picker.Value];
                         _command?.Execute(_picker.Value);
                         ClearFocus();
                     });
@@ -166,8 +157,7 @@ namespace AiForms.Renderers.Droid
                     _dialog = builder.Create();
                 }
                 _dialog.SetCanceledOnTouchOutside(true);
-                _dialog.DismissEvent += (ss, ee) =>
-                {
+                _dialog.DismissEvent += (ss, ee) => {
                     _dialog.Dispose();
                     _dialog = null;
                     _picker.RemoveFromParent();
@@ -181,3 +171,214 @@ namespace AiForms.Renderers.Droid
         }
     }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//using System;
+//using System.Windows.Input;
+//using AiForms.Renderers;
+//using AiForms.Renderers.Droid;
+//using Android.App;
+//using Android.Content;
+//using Android.Views;
+//using Xamarin.Forms;
+//using Xamarin.Forms.Platform.Android;
+//using AListView = Android.Widget.ListView;
+
+//[assembly: ExportRenderer(typeof(TextPickerCell), typeof(TextPickerCellRenderer))]
+//namespace AiForms.Renderers.Droid
+//{
+//    /// <summary>
+//    /// Number picker cell renderer.
+//    /// </summary>
+//    [Android.Runtime.Preserve(AllMembers = true)]
+//    public class TextPickerCellRenderer : CellBaseRenderer<TextPickerCellView> { }
+
+//    /// <summary>
+//    /// Number picker cell view.
+//    /// </summary>
+//    [Android.Runtime.Preserve(AllMembers = true)]
+//    public class TextPickerCellView : LabelCellView, IDialogInterfaceOnShowListener, IDialogInterfaceOnDismissListener
+//    {
+//        TextPickerCell _textPickerCell => Cell as TextPickerCell;
+//        AListView _listView;
+//        TextPickerAdapter _adapter;
+//        AlertDialog _dialog;
+//        Context _context;
+//        string _title;
+//        ICommand _command;
+
+//        /// <summary>
+//        /// Initializes a new instance of the <see cref="T:AiForms.Renderers.Droid.TextPickerCellView"/> class.
+//        /// </summary>
+//        /// <param name="context">Context.</param>
+//        /// <param name="cell">Cell.</param>
+//        public TextPickerCellView(Context context, Cell cell) : base(context, cell)
+//        {
+//            _context = context;
+//        }
+
+//        /// <summary>
+//        /// Cells the property changed.
+//        /// </summary>
+//        /// <param name="sender">Sender.</param>
+//        /// <param name="e">E.</param>
+//        public override void CellPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+//        {
+//            base.CellPropertyChanged(sender, e);
+//            if (e.PropertyName == TextPickerCell.SelectedItemProperty.PropertyName) {
+//                UpdateSelectedItem();
+//            }
+//            else if (e.PropertyName == TextPickerCell.PickerTitleProperty.PropertyName) {
+//                UpdatePickerTitle();
+//            }
+//            else if (e.PropertyName == TextPickerCell.SelectedCommandProperty.PropertyName) {
+//                UpdateCommand();
+//            }
+//        }
+
+//        /// <summary>
+//        /// Updates the cell.
+//        /// </summary>
+//        public override void UpdateCell()
+//        {
+//            base.UpdateCell();
+//            UpdatePickerTitle();
+//            UpdateSelectedItem();
+//            UpdateCommand();
+//        }
+
+//        /// <summary>
+//        /// Dispose the specified disposing.
+//        /// </summary>
+//        /// <returns>The dispose.</returns>
+//        /// <param name="disposing">If set to <c>true</c> disposing.</param>
+//        protected override void Dispose(bool disposing)
+//        {
+//            if (disposing) {
+//                _listView?.Dispose();
+//                _listView = null;
+//                _dialog?.Dispose();
+//                _dialog = null;
+//                _adapter?.Dispose();
+//                _adapter = null;
+//                _context = null;
+//                _command = null;
+//            }
+//            base.Dispose(disposing);
+//        }
+
+//        /// <summary>
+//        /// Shows the dialog.
+//        /// </summary>
+//        public void ShowDialog()
+//        {
+//            CreateDialog();
+//        }
+
+//        void UpdateSelectedItem()
+//        {
+//            vValueLabel.Text = _textPickerCell.SelectedItem.ToString();
+//        }
+
+//        void UpdatePickerTitle()
+//        {
+//            _title = _textPickerCell.PickerTitle;
+//        }
+
+//        void UpdateCommand()
+//        {
+//            _command = _textPickerCell.SelectedCommand;
+//        }
+
+//        void CreateDialog()
+//        {
+//            _listView = new AListView(_context);
+//            _listView.Focusable = false;
+//            _listView.DescendantFocusability = Android.Views.DescendantFocusability.AfterDescendants;
+//            _listView.SetDrawSelectorOnTop(true);
+//            _listView.ChoiceMode = Android.Widget.ChoiceMode.Single;
+//            _adapter = new TextPickerAdapter(_context, _textPickerCell, _listView);
+//            _listView.OnItemClickListener = _adapter;
+//            _listView.Adapter = _adapter;
+
+//            _adapter.CloseAction = () => {
+//                _dialog.GetButton((int)DialogButtonType.Positive).PerformClick();
+//            };
+
+//            if (_dialog == null) {
+//                using (var builder = new AlertDialog.Builder(_context)) {
+//                    builder.SetTitle(_textPickerCell.PageTitle);
+//                    builder.SetView(_listView);
+
+//                    builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) => {
+//                        ClearFocus();
+//                    });
+//                    builder.SetPositiveButton(global::Android.Resource.String.Ok, (o, args) => {
+//                        _adapter.DoneSelect();
+//                        UpdateSelectedItem();
+//                        _textPickerCell.InvokeCommand();
+//                        ClearFocus();
+//                    });
+
+
+//                    _dialog = builder.Create();
+//                }
+
+//                _dialog.SetCanceledOnTouchOutside(true);
+//                _dialog.SetOnDismissListener(this);
+//                _dialog.SetOnShowListener(this);
+//                _dialog.Show();
+//            }
+//        }
+
+//        /// <summary>
+//        /// Ons the show.
+//        /// </summary>
+//        /// <param name="dialog">Dialog.</param>
+//        public void OnShow(IDialogInterface dialog)
+//        {
+//            _adapter.RestoreSelect();
+//        }
+
+//        /// <summary>
+//        /// Ons the dismiss.
+//        /// </summary>
+//        /// <param name="dialog">Dialog.</param>
+//        public void OnDismiss(IDialogInterface dialog)
+//        {
+//            _dialog.SetOnShowListener(null);
+//            _dialog.SetOnDismissListener(null);
+//            _dialog.Dispose();
+//            _dialog = null;
+//            _adapter?.Dispose();
+//            _adapter = null;
+//            _listView.Dispose();
+//            _listView = null;
+//            this.Selected = false;
+//        }
+//    }
+//}

--- a/SettingsView.Droid/Cells/TextPickerCellRenderer.cs
+++ b/SettingsView.Droid/Cells/TextPickerCellRenderer.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Windows.Input;
+using AiForms.Renderers;
+using AiForms.Renderers.Droid;
+using Android.App;
+using Android.Content;
+using Android.Views;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+using APicker = Android.Widget.NumberPicker;
+
+[assembly: ExportRenderer(typeof(NumberPickerCell), typeof(NumberPickerCellRenderer))]
+namespace AiForms.Renderers.Droid
+{
+    /// <summary>
+    /// Number picker cell renderer.
+    /// </summary>
+    [Android.Runtime.Preserve(AllMembers = true)]
+    public class NumberPickerCellRenderer : CellBaseRenderer<NumberPickerCellView> { }
+
+    /// <summary>
+    /// Number picker cell view.
+    /// </summary>
+    [Android.Runtime.Preserve(AllMembers = true)]
+    public class NumberPickerCellView : LabelCellView, IPickerCell
+    {
+        NumberPickerCell _NumberPikcerCell => Cell as NumberPickerCell;
+        APicker _picker;
+        AlertDialog _dialog;
+        Context _context;
+        string _title;
+        ICommand _command;
+        int _max;
+        int _min;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:AiForms.Renderers.Droid.NumberPickerCellView"/> class.
+        /// </summary>
+        /// <param name="context">Context.</param>
+        /// <param name="cell">Cell.</param>
+        public NumberPickerCellView(Context context, Cell cell) : base(context, cell)
+        {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Cells the property changed.
+        /// </summary>
+        /// <param name="sender">Sender.</param>
+        /// <param name="e">E.</param>
+        public override void CellPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            base.CellPropertyChanged(sender, e);
+            if (e.PropertyName == NumberPickerCell.MinProperty.PropertyName) {
+                UpdateMin();
+            }
+            else if (e.PropertyName == NumberPickerCell.MaxProperty.PropertyName) {
+                UpdateMax();
+            }
+            else if (e.PropertyName == NumberPickerCell.NumberProperty.PropertyName) {
+                UpdateNumber();
+            }
+            else if (e.PropertyName == NumberPickerCell.PickerTitleProperty.PropertyName) {
+                UpdatePickerTitle();
+            }
+            else if (e.PropertyName == NumberPickerCell.SelectedCommandProperty.PropertyName) {
+                UpdateCommand();
+            }
+        }
+
+        /// <summary>
+        /// Updates the cell.
+        /// </summary>
+        public override void UpdateCell()
+        {
+            base.UpdateCell();
+            UpdateMin();
+            UpdateMax();
+            UpdatePickerTitle();
+            UpdateNumber();
+            UpdateCommand();
+        }
+
+        /// <summary>
+        /// Dispose the specified disposing.
+        /// </summary>
+        /// <returns>The dispose.</returns>
+        /// <param name="disposing">If set to <c>true</c> disposing.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) {
+                _picker?.Dispose();
+                _picker = null;
+                _dialog?.Dispose();
+                _dialog = null;
+                _context = null;
+                _command = null;
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Shows the dialog.
+        /// </summary>
+        public void ShowDialog()
+        {
+            CreateDialog();
+        }
+
+        void UpdateMin()
+        {
+            _min = _NumberPikcerCell.Min;
+        }
+
+        void UpdateMax()
+        {
+            _max = _NumberPikcerCell.Max;
+        }
+
+        void UpdateNumber()
+        {
+            vValueLabel.Text = _NumberPikcerCell.Number.ToString();
+        }
+
+        void UpdatePickerTitle()
+        {
+            _title = _NumberPikcerCell.PickerTitle;
+        }
+
+        void UpdateCommand()
+        {
+            _command = _NumberPikcerCell.SelectedCommand;
+        }
+
+        void CreateDialog()
+        {
+            _picker = new APicker(_context);
+            _picker.MinValue = _min;
+            _picker.MaxValue = _max;
+            _picker.Value = _NumberPikcerCell.Number;
+
+            if (_dialog == null) {
+                using (var builder = new AlertDialog.Builder(_context)) {
+
+                    builder.SetTitle(_title);
+
+                    Android.Widget.FrameLayout parent = new Android.Widget.FrameLayout(_context);
+                    parent.AddView(_picker, new Android.Widget.FrameLayout.LayoutParams(
+                            ViewGroup.LayoutParams.WrapContent,
+                            ViewGroup.LayoutParams.WrapContent,
+                           GravityFlags.Center));
+                    builder.SetView(parent);
+
+
+                    builder.SetNegativeButton(global::Android.Resource.String.Cancel, (o, args) =>
+                    {
+                        ClearFocus();
+                    });
+                    builder.SetPositiveButton(global::Android.Resource.String.Ok, (o, args) =>
+                    {
+                        _NumberPikcerCell.Number = _picker.Value;
+                        _command?.Execute(_picker.Value);
+                        ClearFocus();
+                    });
+
+                    _dialog = builder.Create();
+                }
+                _dialog.SetCanceledOnTouchOutside(true);
+                _dialog.DismissEvent += (ss, ee) =>
+                {
+                    _dialog.Dispose();
+                    _dialog = null;
+                    _picker.RemoveFromParent();
+                    _picker.Dispose();
+                    _picker = null;
+                };
+
+                _dialog.Show();
+            }
+
+        }
+    }
+}

--- a/SettingsView.Droid/SettingsView.Droid.csproj
+++ b/SettingsView.Droid/SettingsView.Droid.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AiForms.Renderers.Droid</RootNamespace>
     <AssemblyName>SettingsView.Droid</AssemblyName>
-    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
@@ -132,6 +132,7 @@
     <Compile Include="Cells\ButtonCellRenderer.cs" />
     <Compile Include="Cells\ICheckableCell.cs" />
     <Compile Include="SettingsViewRecyclerAdapter.cs" />
+    <Compile Include="Cells\TextPickerCellRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />

--- a/SettingsView.iOS/Cells/TextPickerCellRenderer.cs
+++ b/SettingsView.iOS/Cells/TextPickerCellRenderer.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Windows.Input;
+using AiForms.Renderers;
+using AiForms.Renderers.iOS;
+using CoreGraphics;
+using UIKit;
+using Xamarin.Forms;
+
+[assembly: ExportRenderer(typeof(NumberPickerCell), typeof(NumberPickerCellRenderer))]
+namespace AiForms.Renderers.iOS
+{
+    /// <summary>
+    /// Number picker cell renderer.
+    /// </summary>
+    public class NumberPickerCellRenderer : CellBaseRenderer<NumberPickerCellView> { }
+
+    /// <summary>
+    /// Number picker cell view.
+    /// </summary>
+    public class NumberPickerCellView : LabelCellView, IPickerCell
+    {
+        /// <summary>
+        /// Gets or sets the dummy field.
+        /// </summary>
+        /// <value>The dummy field.</value>
+        public UITextField DummyField { get; set; }
+        NumberPickerSource _model;
+        UILabel _titleLabel;
+        UIPickerView _picker;
+        ICommand _command;
+
+        NumberPickerCell _NumberPikcerCell => Cell as NumberPickerCell;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:AiForms.Renderers.iOS.NumberPickerCellView"/> class.
+        /// </summary>
+        /// <param name="formsCell">Forms cell.</param>
+        public NumberPickerCellView(Cell formsCell) : base(formsCell)
+        {
+
+            DummyField = new NoCaretField();
+            DummyField.BorderStyle = UITextBorderStyle.None;
+            DummyField.BackgroundColor = UIColor.Clear;
+            ContentView.AddSubview(DummyField);
+            ContentView.SendSubviewToBack(DummyField);
+
+            SelectionStyle = UITableViewCellSelectionStyle.Default;
+
+            SetUpPicker();
+        }
+
+        /// <summary>
+        /// Cells the property changed.
+        /// </summary>
+        /// <param name="sender">Sender.</param>
+        /// <param name="e">E.</param>
+        public override void CellPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            base.CellPropertyChanged(sender, e);
+            if (e.PropertyName == NumberPickerCell.MinProperty.PropertyName ||
+                e.PropertyName == NumberPickerCell.MaxProperty.PropertyName) {
+                UpdateNumberList();
+            }
+            else if (e.PropertyName == NumberPickerCell.NumberProperty.PropertyName) {
+                UpdateNumber();
+            }
+            else if (e.PropertyName == NumberPickerCell.PickerTitleProperty.PropertyName) {
+                UpdateTitle();
+
+            }
+            else if (e.PropertyName == NumberPickerCell.SelectedCommandProperty.PropertyName) {
+                UpdateCommand();
+            }
+        }
+
+        /// <summary>
+        /// Updates the cell.
+        /// </summary>
+        public override void UpdateCell()
+        {
+            base.UpdateCell();
+            UpdateNumberList();
+            UpdateNumber();
+            UpdateTitle();
+            UpdateCommand();
+        }
+
+        /// <summary>
+        /// Dispose the specified disposing.
+        /// </summary>
+        /// <returns>The dispose.</returns>
+        /// <param name="disposing">If set to <c>true</c> disposing.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) {
+                DummyField.RemoveFromSuperview();
+                DummyField?.Dispose();
+                DummyField = null;
+                _titleLabel?.Dispose();
+                _titleLabel = null;
+                _model?.Dispose();
+                _model = null;
+                _picker?.Dispose();
+                _picker = null;
+                _command = null;
+
+            }
+            base.Dispose(disposing);
+        }
+
+        void SetUpPicker()
+        {
+            _picker = new UIPickerView();
+
+            var width = UIScreen.MainScreen.Bounds.Width;
+
+            _titleLabel = new UILabel();
+            _titleLabel.TextAlignment = UITextAlignment.Center;
+
+            var toolbar = new UIToolbar(new CGRect(0, 0, (float)width, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
+            var cancelButton = new UIBarButtonItem(UIBarButtonSystemItem.Cancel, (o, e) =>
+            {
+                DummyField.ResignFirstResponder();
+                Select(_model.PreSelectedItem);
+            });
+
+            var labelButton = new UIBarButtonItem(_titleLabel);
+            var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);
+            var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) =>
+            {
+                _model.OnUpdatePickerFormModel();
+                DummyField.ResignFirstResponder();
+                _command?.Execute(_model.SelectedItem);
+            });
+
+            toolbar.SetItems(new[] { cancelButton, spacer, labelButton, spacer, doneButton }, false);
+
+            DummyField.InputView = _picker;
+            DummyField.InputAccessoryView = toolbar;
+
+            _model = new NumberPickerSource();
+            _picker.Model = _model;
+
+            _model.UpdatePickerFromModel += Model_UpdatePickerFromModel;
+        }
+
+        void UpdateNumber()
+        {
+            Select(_NumberPikcerCell.Number);
+            ValueLabel.Text = _NumberPikcerCell.Number.ToString();
+        }
+
+        void UpdateNumberList()
+        {
+            _model.SetNumbers(_NumberPikcerCell.Min, _NumberPikcerCell.Max);
+            Select(_NumberPikcerCell.Number);
+        }
+
+        void UpdateTitle()
+        {
+            _titleLabel.Text = _NumberPikcerCell.PickerTitle;
+            _titleLabel.SizeToFit();
+            _titleLabel.Frame = new CGRect(0, 0, 160, 44);
+        }
+
+        void UpdateCommand()
+        {
+            _command = _NumberPikcerCell.SelectedCommand;
+        }
+
+        void Model_UpdatePickerFromModel(object sender, EventArgs e)
+        {
+            _NumberPikcerCell.Number = _model.SelectedItem;
+            ValueLabel.Text = _model.SelectedItem.ToString();
+        }
+
+        /// <summary>
+        /// Layouts the subviews.
+        /// </summary>
+        public override void LayoutSubviews()
+        {
+            base.LayoutSubviews();
+
+            DummyField.Frame = new CGRect(0, 0, Frame.Width, Frame.Height);
+        }
+
+        void Select(int number)
+        {
+            var idx = _model.Items.IndexOf(number);
+            if (idx == -1) {
+                number = _model.Items[0];
+                idx = 0;
+            }
+            _picker.Select(idx, 0, false);
+            _model.SelectedItem = number;
+            _model.SelectedIndex = idx;
+            _model.PreSelectedItem = number;
+        }
+    }
+}

--- a/SettingsView.iOS/Cells/TextPickerCellRenderer.cs
+++ b/SettingsView.iOS/Cells/TextPickerCellRenderer.cs
@@ -6,36 +6,36 @@ using CoreGraphics;
 using UIKit;
 using Xamarin.Forms;
 
-[assembly: ExportRenderer(typeof(NumberPickerCell), typeof(NumberPickerCellRenderer))]
+[assembly: ExportRenderer(typeof(TextPickerCell), typeof(TextPickerCellRenderer))]
 namespace AiForms.Renderers.iOS
 {
     /// <summary>
     /// Number picker cell renderer.
     /// </summary>
-    public class NumberPickerCellRenderer : CellBaseRenderer<NumberPickerCellView> { }
+    public class TextPickerCellRenderer : CellBaseRenderer<TextPickerCellView> { }
 
     /// <summary>
     /// Number picker cell view.
     /// </summary>
-    public class NumberPickerCellView : LabelCellView, IPickerCell
+    public class TextPickerCellView : LabelCellView, IPickerCell
     {
         /// <summary>
         /// Gets or sets the dummy field.
         /// </summary>
         /// <value>The dummy field.</value>
         public UITextField DummyField { get; set; }
-        NumberPickerSource _model;
+        TextPickerSource _model;
         UILabel _titleLabel;
         UIPickerView _picker;
         ICommand _command;
 
-        NumberPickerCell _NumberPikcerCell => Cell as NumberPickerCell;
+        TextPickerCell _TextPickerCell => Cell as TextPickerCell;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:AiForms.Renderers.iOS.NumberPickerCellView"/> class.
+        /// Initializes a new instance of the <see cref="T:AiForms.Renderers.iOS.TextPickerCellView"/> class.
         /// </summary>
         /// <param name="formsCell">Forms cell.</param>
-        public NumberPickerCellView(Cell formsCell) : base(formsCell)
+        public TextPickerCellView(Cell formsCell) : base(formsCell)
         {
 
             DummyField = new NoCaretField();
@@ -57,18 +57,14 @@ namespace AiForms.Renderers.iOS
         public override void CellPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             base.CellPropertyChanged(sender, e);
-            if (e.PropertyName == NumberPickerCell.MinProperty.PropertyName ||
-                e.PropertyName == NumberPickerCell.MaxProperty.PropertyName) {
-                UpdateNumberList();
-            }
-            else if (e.PropertyName == NumberPickerCell.NumberProperty.PropertyName) {
-                UpdateNumber();
-            }
-            else if (e.PropertyName == NumberPickerCell.PickerTitleProperty.PropertyName) {
-                UpdateTitle();
 
+            if (e.PropertyName == TextPickerCell.SelectedItemProperty.PropertyName) {
+                UpdateSelectedItem();
             }
-            else if (e.PropertyName == NumberPickerCell.SelectedCommandProperty.PropertyName) {
+            else if (e.PropertyName == TextPickerCell.PickerTitleProperty.PropertyName) {
+                UpdateTitle();
+            }
+            else if (e.PropertyName == TextPickerCell.SelectedCommandProperty.PropertyName) {
                 UpdateCommand();
             }
         }
@@ -79,8 +75,8 @@ namespace AiForms.Renderers.iOS
         public override void UpdateCell()
         {
             base.UpdateCell();
-            UpdateNumberList();
-            UpdateNumber();
+            UpdateItemsList();
+            UpdateSelectedItem();
             UpdateTitle();
             UpdateCommand();
         }
@@ -138,39 +134,39 @@ namespace AiForms.Renderers.iOS
             DummyField.InputView = _picker;
             DummyField.InputAccessoryView = toolbar;
 
-            _model = new NumberPickerSource();
+            _model = new TextPickerSource();
             _picker.Model = _model;
 
             _model.UpdatePickerFromModel += Model_UpdatePickerFromModel;
         }
 
-        void UpdateNumber()
+        void UpdateSelectedItem()
         {
-            Select(_NumberPikcerCell.Number);
-            ValueLabel.Text = _NumberPikcerCell.Number.ToString();
+            Select(_TextPickerCell.SelectedItem);
+            ValueLabel.Text = _TextPickerCell.SelectedItem.ToString();
         }
 
-        void UpdateNumberList()
+        void UpdateItemsList()
         {
-            _model.SetNumbers(_NumberPikcerCell.Min, _NumberPikcerCell.Max);
-            Select(_NumberPikcerCell.Number);
+            _model.SetItems(_TextPickerCell.Items);
+            Select(_TextPickerCell.SelectedItem);
         }
 
         void UpdateTitle()
         {
-            _titleLabel.Text = _NumberPikcerCell.PickerTitle;
+            _titleLabel.Text = _TextPickerCell.PickerTitle;
             _titleLabel.SizeToFit();
             _titleLabel.Frame = new CGRect(0, 0, 160, 44);
         }
 
         void UpdateCommand()
         {
-            _command = _NumberPikcerCell.SelectedCommand;
+            _command = _TextPickerCell.SelectedCommand;
         }
 
         void Model_UpdatePickerFromModel(object sender, EventArgs e)
         {
-            _NumberPikcerCell.Number = _model.SelectedItem;
+            _TextPickerCell.SelectedItem = _model.SelectedItem;
             ValueLabel.Text = _model.SelectedItem.ToString();
         }
 
@@ -184,17 +180,17 @@ namespace AiForms.Renderers.iOS
             DummyField.Frame = new CGRect(0, 0, Frame.Width, Frame.Height);
         }
 
-        void Select(int number)
+        void Select(string item)
         {
-            var idx = _model.Items.IndexOf(number);
+            var idx = _model.Items.IndexOf(item);
             if (idx == -1) {
-                number = _model.Items[0];
+                item = _model.Items[0];
                 idx = 0;
             }
             _picker.Select(idx, 0, false);
-            _model.SelectedItem = number;
+            _model.SelectedItem = item;
             _model.SelectedIndex = idx;
-            _model.PreSelectedItem = number;
+            _model.PreSelectedItem = item;
         }
     }
 }

--- a/SettingsView.iOS/Cells/TextPickerSource.cs
+++ b/SettingsView.iOS/Cells/TextPickerSource.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UIKit;
+
+namespace AiForms.Renderers.iOS
+{
+    internal class NumberPickerSource : UIPickerViewModel
+    {
+
+        internal IList<int> Items { get; private set; }
+
+        internal event EventHandler UpdatePickerFromModel;
+
+        internal int SelectedIndex { get; set; }
+
+        internal int SelectedItem { get; set; }
+
+        internal int PreSelectedItem { get; set; }
+
+        /// <summary>
+        /// Gets the component count.
+        /// </summary>
+        /// <returns>The component count.</returns>
+        /// <param name="picker">Picker.</param>
+        public override nint GetComponentCount(UIPickerView picker)
+        {
+            return 1;
+        }
+
+        /// <summary>
+        /// Gets the rows in component.
+        /// </summary>
+        /// <returns>The rows in component.</returns>
+        /// <param name="pickerView">Picker view.</param>
+        /// <param name="component">Component.</param>
+        public override nint GetRowsInComponent(UIPickerView pickerView, nint component)
+        {
+            return Items != null ? Items.Count : 0;
+        }
+
+        /// <summary>
+        /// Gets the title.
+        /// </summary>
+        /// <returns>The title.</returns>
+        /// <param name="picker">Picker.</param>
+        /// <param name="row">Row.</param>
+        /// <param name="component">Component.</param>
+        public override string GetTitle(UIPickerView picker, nint row, nint component)
+        {
+            return Items[(int)row].ToString();
+        }
+
+        /// <summary>
+        /// Selected the specified picker, row and component.
+        /// </summary>
+        /// <returns>The selected.</returns>
+        /// <param name="picker">Picker.</param>
+        /// <param name="row">Row.</param>
+        /// <param name="component">Component.</param>
+        public override void Selected(UIPickerView picker, nint row, nint component)
+        {
+
+            if (Items.Count == 0) {
+                SelectedItem = 0;
+                SelectedIndex = -1;
+            }
+            else {
+                SelectedItem = Items[(int)row];
+                SelectedIndex = (int)row;
+            }
+
+        }
+
+        /// <summary>
+        /// Sets the numbers.
+        /// </summary>
+        /// <param name="min">Minimum.</param>
+        /// <param name="max">Max.</param>
+        public void SetNumbers(int min, int max)
+        {
+            if (min < 0) min = 0;
+            if (max < 0) max = 0;
+            if (min > max) {
+                throw new ArgumentOutOfRangeException(
+                    nameof(NumberPickerCell.Max),
+                    "Max value must be greater than or equal to Min value."
+                );
+            }
+            Items = Enumerable.Range(min, max - min + 1).ToList();
+        }
+
+        /// <summary>
+        /// Ons the update picker form model.
+        /// </summary>
+        public void OnUpdatePickerFormModel()
+        {
+            PreSelectedItem = SelectedItem;
+            UpdatePickerFromModel?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/SettingsView.iOS/Cells/TextPickerSource.cs
+++ b/SettingsView.iOS/Cells/TextPickerSource.cs
@@ -5,18 +5,18 @@ using UIKit;
 
 namespace AiForms.Renderers.iOS
 {
-    internal class NumberPickerSource : UIPickerViewModel
+    internal class TextPickerSource : UIPickerViewModel
     {
 
-        internal IList<int> Items { get; private set; }
+        internal IList<string> Items { get; private set; }
 
         internal event EventHandler UpdatePickerFromModel;
 
         internal int SelectedIndex { get; set; }
 
-        internal int SelectedItem { get; set; }
+        internal string SelectedItem { get; set; }
 
-        internal int PreSelectedItem { get; set; }
+        internal string PreSelectedItem { get; set; }
 
         /// <summary>
         /// Gets the component count.
@@ -62,7 +62,7 @@ namespace AiForms.Renderers.iOS
         {
 
             if (Items.Count == 0) {
-                SelectedItem = 0;
+                SelectedItem = String.Empty;
                 SelectedIndex = -1;
             }
             else {
@@ -77,17 +77,9 @@ namespace AiForms.Renderers.iOS
         /// </summary>
         /// <param name="min">Minimum.</param>
         /// <param name="max">Max.</param>
-        public void SetNumbers(int min, int max)
+        public void SetItems(IList<string> items)
         {
-            if (min < 0) min = 0;
-            if (max < 0) max = 0;
-            if (min > max) {
-                throw new ArgumentOutOfRangeException(
-                    nameof(NumberPickerCell.Max),
-                    "Max value must be greater than or equal to Min value."
-                );
-            }
-            Items = Enumerable.Range(min, max - min + 1).ToList();
+            Items = items;
         }
 
         /// <summary>

--- a/SettingsView.iOS/SettingsView.iOS.csproj
+++ b/SettingsView.iOS/SettingsView.iOS.csproj
@@ -50,14 +50,14 @@
     <Reference Include="Xamarin.Forms.Core">
       <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.Forms.Platform.iOS">
       <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
       <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.2.5.0.121934\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -92,6 +92,8 @@
     <Compile Include="Extensions\TextAlignmentExtensions.cs" />
     <Compile Include="Cells\ButtonCellRenderer.cs" />
     <Compile Include="SettingsLagacyTableSource.cs" />
+    <Compile Include="Cells\TextPickerCellRenderer.cs" />
+    <Compile Include="Cells\TextPickerSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SettingsView\SettingsView.csproj">

--- a/SettingsView/Cells/TextPickerCell.cs
+++ b/SettingsView/Cells/TextPickerCell.cs
@@ -1,75 +1,78 @@
 ﻿using System;
 using Xamarin.Forms;
 using System.Windows.Input;
+using System.Collections.Generic;
 
 namespace AiForms.Renderers
 {
     /// <summary>
-    /// Number picker cell.
+    /// Text picker cell.
     /// </summary>
-    public class NumberPickerCell:LabelCell
+    public class TextPickerCell:LabelCell
     {
+        public IList<string> Items { get; set; } = new List<string>();
+
         /// <summary>
-        /// The number property.
+        /// The page title property.
         /// </summary>
-        public static BindableProperty NumberProperty =
+        public static BindableProperty PageTitleProperty =
             BindableProperty.Create(
-                nameof(Number),
-                typeof(int),
-                typeof(NumberPickerCell),
-                default(int),
+                nameof(PageTitle),
+                typeof(string),
+                typeof(PickerCell),
+                default(string),
+                defaultBindingMode: BindingMode.OneWay
+            );
+
+        /// <summary>
+        /// Gets or sets the page title.
+        /// </summary>
+        /// <value>The page title.</value>
+        public string PageTitle {
+            get { return (string)GetValue(PageTitleProperty); }
+            set { SetValue(PageTitleProperty, value); }
+        }
+
+        /// <summary>
+        /// The accent color property.
+        /// </summary>
+        public static BindableProperty AccentColorProperty =
+            BindableProperty.Create(
+                nameof(AccentColor),
+                typeof(Color),
+                typeof(PickerCell),
+                default(Color),
+                defaultBindingMode: BindingMode.OneWay
+            );
+
+        /// <summary>
+        /// Gets or sets the color of the accent.
+        /// </summary>
+        /// <value>The color of the accent.</value>
+        public Color AccentColor {
+            get { return (Color)GetValue(AccentColorProperty); }
+            set { SetValue(AccentColorProperty, value); }
+        }
+
+        /// <summary>
+        /// The selected item property.
+        /// </summary>
+        public static BindableProperty SelectedItemProperty =
+            BindableProperty.Create(
+                nameof(SelectedItem),
+                typeof(string),
+                typeof(TextPickerCell),
+                default(string),
                 defaultBindingMode: BindingMode.TwoWay
             );
 
         /// <summary>
-        /// Gets or sets the number.
+        /// Gets or sets the selected number.
         /// </summary>
-        /// <value>The number.</value>
-        public int Number {
-            get { return (int)GetValue(NumberProperty); }
-            set { SetValue(NumberProperty, value); }
-        }
-
-        /// <summary>
-        /// The minimum property.
-        /// </summary>
-        public static BindableProperty MinProperty =
-            BindableProperty.Create(
-                nameof(Min),
-                typeof(int),
-                typeof(NumberPickerCell),
-                0,
-                defaultBindingMode: BindingMode.OneWay
-            );
-
-        /// <summary>
-        /// Gets or sets the minimum.
-        /// </summary>
-        /// <value>The minimum.</value>
-        public int Min {
-            get { return (int)GetValue(MinProperty); }
-            set { SetValue(MinProperty, value); }
-        }
-
-        /// <summary>
-        /// The max property.
-        /// </summary>
-        public static BindableProperty MaxProperty =
-            BindableProperty.Create(
-                nameof(Max),
-                typeof(int),
-                typeof(NumberPickerCell),
-                9999,
-                defaultBindingMode: BindingMode.OneWay
-            );
-
-        /// <summary>
-        /// Gets or sets the max.
-        /// </summary>
-        /// <value>The max.</value>
-        public int Max {
-            get { return (int)GetValue(MaxProperty); }
-            set { SetValue(MaxProperty, value); }
+        /// <value>The text value.</value>
+        public string SelectedItem {
+            get { return (string)GetValue(SelectedItemProperty); }
+            set { SetValue(SelectedItemProperty, value); }
         }
 
         /// <summary>
@@ -79,7 +82,7 @@ namespace AiForms.Renderers
             BindableProperty.Create(
                 nameof(PickerTitle),
                 typeof(string),
-                typeof(NumberPickerCell),
+                typeof(TextPickerCell),
                 default(string),
                 defaultBindingMode: BindingMode.OneWay
             );
@@ -100,7 +103,7 @@ namespace AiForms.Renderers
             BindableProperty.Create(
                 nameof(SelectedCommand),
                 typeof(ICommand),
-                typeof(NumberPickerCell),
+                typeof(TextPickerCell),
                 default(ICommand),
                 defaultBindingMode: BindingMode.OneWay
             );
@@ -115,5 +118,23 @@ namespace AiForms.Renderers
         }
 
         private new string ValueText { get; set; }
+
+        ////DisplayMember getter
+        //internal Func<object, object> DisplayValue {
+        //    get {
+        //            return (obj) => obj;
+        //    }
+        //}
+
+        //internal Func<object, object> SubDisplayValue {
+        //    get {
+        //            return (obj) => null;
+        //    }
+        //}
+
+        //internal void InvokeCommand()
+        //{
+        //    SelectedCommand?.Execute(SelectedItem);
+        //}
     }
 }

--- a/SettingsView/Cells/TextPickerCell.cs
+++ b/SettingsView/Cells/TextPickerCell.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using Xamarin.Forms;
+using System.Windows.Input;
+
+namespace AiForms.Renderers
+{
+    /// <summary>
+    /// Number picker cell.
+    /// </summary>
+    public class NumberPickerCell:LabelCell
+    {
+        /// <summary>
+        /// The number property.
+        /// </summary>
+        public static BindableProperty NumberProperty =
+            BindableProperty.Create(
+                nameof(Number),
+                typeof(int),
+                typeof(NumberPickerCell),
+                default(int),
+                defaultBindingMode: BindingMode.TwoWay
+            );
+
+        /// <summary>
+        /// Gets or sets the number.
+        /// </summary>
+        /// <value>The number.</value>
+        public int Number {
+            get { return (int)GetValue(NumberProperty); }
+            set { SetValue(NumberProperty, value); }
+        }
+
+        /// <summary>
+        /// The minimum property.
+        /// </summary>
+        public static BindableProperty MinProperty =
+            BindableProperty.Create(
+                nameof(Min),
+                typeof(int),
+                typeof(NumberPickerCell),
+                0,
+                defaultBindingMode: BindingMode.OneWay
+            );
+
+        /// <summary>
+        /// Gets or sets the minimum.
+        /// </summary>
+        /// <value>The minimum.</value>
+        public int Min {
+            get { return (int)GetValue(MinProperty); }
+            set { SetValue(MinProperty, value); }
+        }
+
+        /// <summary>
+        /// The max property.
+        /// </summary>
+        public static BindableProperty MaxProperty =
+            BindableProperty.Create(
+                nameof(Max),
+                typeof(int),
+                typeof(NumberPickerCell),
+                9999,
+                defaultBindingMode: BindingMode.OneWay
+            );
+
+        /// <summary>
+        /// Gets or sets the max.
+        /// </summary>
+        /// <value>The max.</value>
+        public int Max {
+            get { return (int)GetValue(MaxProperty); }
+            set { SetValue(MaxProperty, value); }
+        }
+
+        /// <summary>
+        /// The picker title property.
+        /// </summary>
+        public static BindableProperty PickerTitleProperty =
+            BindableProperty.Create(
+                nameof(PickerTitle),
+                typeof(string),
+                typeof(NumberPickerCell),
+                default(string),
+                defaultBindingMode: BindingMode.OneWay
+            );
+
+        /// <summary>
+        /// Gets or sets the picker title.
+        /// </summary>
+        /// <value>The picker title.</value>
+        public string PickerTitle {
+            get { return (string)GetValue(PickerTitleProperty); }
+            set { SetValue(PickerTitleProperty, value); }
+        }
+
+        /// <summary>
+        /// The selected command property.
+        /// </summary>
+        public static BindableProperty SelectedCommandProperty =
+            BindableProperty.Create(
+                nameof(SelectedCommand),
+                typeof(ICommand),
+                typeof(NumberPickerCell),
+                default(ICommand),
+                defaultBindingMode: BindingMode.OneWay
+            );
+
+        /// <summary>
+        /// Gets or sets the selected command.
+        /// </summary>
+        /// <value>The selected command.</value>
+        public ICommand SelectedCommand {
+            get { return (ICommand)GetValue(SelectedCommandProperty); }
+            set { SetValue(SelectedCommandProperty, value); }
+        }
+
+        private new string ValueText { get; set; }
+    }
+}

--- a/SettingsView/SettingsView.csproj
+++ b/SettingsView/SettingsView.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Cells\CheckboxCell.cs" />
     <Compile Include="NaturalComparer.cs" />
     <Compile Include="Cells\ButtonCell.cs" />
+    <Compile Include="Cells\TextPickerCell.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Cells\" />

--- a/SettingsView/SettingsView.nuget.props
+++ b/SettingsView/SettingsView.nuget.props
@@ -3,9 +3,9 @@
   <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
     <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
     <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
-    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">/Users/kamu/Projects/AiForms.Renderers/SettingsView/project.lock.json</ProjectAssetsFile>
-    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">/Users/kamu/.nuget/packages/</NuGetPackageRoot>
-    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">/Users/kamu/.nuget/packages/</NuGetPackageFolders>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">/Users/jeff/Projects/AiForms.Renderers/SettingsView/project.lock.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">/Users/jeff/.nuget/packages/</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">/Users/jeff/.nuget/packages/</NuGetPackageFolders>
     <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">ProjectJson</NuGetProjectStyle>
     <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.3.1</NuGetToolVersion>
   </PropertyGroup>


### PR DESCRIPTION
Per Issue #24, I created a new TextPickerCell that works very similar to the NumberPickerCell but has a list of strings instead of a range of numbers. This is a little cleaner for "pick one item" in that it doesn't have to go to another screen (iOS) or display a large list (Android.)

I left the references in the Sample project pointing to the local SettingsView project for testing. The original copy used the current Nuget package.